### PR TITLE
De-hardcoded the URL with RAGMAN_BACKEND_HOST as env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ When deploying the application, the following environment variables can be set:
 
 | Environment Variable              | Default value                  | Description                                                                                                                               |
 | --------------------------------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| RAGMAN_BACKEND_HOST               |                                | The url for the
+server
 | NEXT_PUBLIC_NAME                  |                                | The user-facing name of the app                                                                                   |
 | OPENAI_API_KEY                    |                                | The default API key used for authentication with OpenAI                                                                                   |
 | OPENAI_API_HOST                   | `https://api.openai.com`       | The base url, for Azure use `https://<endpoint>.openai.azure.com`                                                                         |

--- a/pages/api/chat.ts
+++ b/pages/api/chat.ts
@@ -16,7 +16,6 @@ export const config = {
 const handler = async (req: Request): Promise<Response> => {
   try {
     const { model, messages, key, prompt, temperature, cid } = (await req.json()) as ChatBody;
-    console.log("THIS IS MY CID:", cid);
 
     await init((imports) => WebAssembly.instantiate(wasm, imports));
     const encoding = new Tiktoken(

--- a/pages/api/models.ts
+++ b/pages/api/models.ts
@@ -17,7 +17,7 @@ const handler = async (req: Request): Promise<Response> => {
     //   url = `${OPENAI_API_HOST}/openai/deployments?api-version=${OPENAI_API_VERSION}`;
     // }
 
-    let url = process.env.RAGMAN_BACKEND_HOST + ":5000/models"
+    let url = process.env.RAGMAN_BACKEND_HOST + "/models"
 
     const response = await fetch(url, {
       headers: {

--- a/pages/api/models.ts
+++ b/pages/api/models.ts
@@ -17,7 +17,7 @@ const handler = async (req: Request): Promise<Response> => {
     //   url = `${OPENAI_API_HOST}/openai/deployments?api-version=${OPENAI_API_VERSION}`;
     // }
 
-    let url = "http://127.0.0.1:5000/models"
+    let url = process.env.RAGMAN_BACKEND_HOST + ":5000/models"
 
     const response = await fetch(url, {
       headers: {

--- a/types/env.ts
+++ b/types/env.ts
@@ -5,4 +5,5 @@ export interface ProcessEnv {
   OPENAI_API_VERSION?: string;
   OPENAI_ORGANIZATION?: string;
   NEXT_PUBLIC_NAME?: string;
+  RAGMAN_BACKEND_HOST?: string;
 }

--- a/utils/server/index.ts
+++ b/utils/server/index.ts
@@ -36,7 +36,7 @@ export const OpenAIStream = async (
   //   url = `${OPENAI_API_HOST}/openai/deployments/${AZURE_DEPLOYMENT_ID}/chat/completions?api-version=${OPENAI_API_VERSION}`;
   // }
 
-  let url = process.env.RAGMAN_BACKEND_HOST + ":5000/chat"
+  let url = process.env.RAGMAN_BACKEND_HOST + "/chat"
   const res = await fetch(url, {
     headers: {
       'Content-Type': 'application/json',

--- a/utils/server/index.ts
+++ b/utils/server/index.ts
@@ -36,7 +36,7 @@ export const OpenAIStream = async (
   //   url = `${OPENAI_API_HOST}/openai/deployments/${AZURE_DEPLOYMENT_ID}/chat/completions?api-version=${OPENAI_API_VERSION}`;
   // }
 
-  let url = "http://127.0.0.1:5000/chat"
+  let url = process.env.RAGMAN_BACKEND_HOST + ":5000/chat"
   const res = await fetch(url, {
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
Added RAGMAN_BACKEND_HOST as an environment variable to be able to set the server URL without hardcoding the server URL in different files.